### PR TITLE
Fix of deprecated Twig_Function_Method call

### DIFF
--- a/Graphic/Flot/Twig/Extension/FlotTwigExtension.php
+++ b/Graphic/Flot/Twig/Extension/FlotTwigExtension.php
@@ -10,13 +10,15 @@ class FlotTwigExtension extends \Twig_Extension {
      */
     public function getFunctions() {
         return array(
-            'flot_graph' => new \Twig_Function_Method($this, 'flotGraph',
-                    array(
-                        'is_safe' => array('html', 'js'),
-                        'needs_environment' => true
-                    )
-                )
-         );
+            new \Twig_SimpleFunction(
+                'flot_graph',
+                [$this, 'flotGraph'],
+                [
+                    'is_safe' => array('html', 'js'),
+                    'needs_environment' => true
+                ]
+            ),
+        );
     }
 
     /**

--- a/Graphic/Flot/Twig/Extension/FlotTwigExtension.php
+++ b/Graphic/Flot/Twig/Extension/FlotTwigExtension.php
@@ -9,16 +9,16 @@ class FlotTwigExtension extends \Twig_Extension {
      * {@inheritdoc}
      */
     public function getFunctions() {
-        return array(
+        return [
             new \Twig_SimpleFunction(
                 'flot_graph',
                 [$this, 'flotGraph'],
                 [
-                    'is_safe' => array('html', 'js'),
+                    'is_safe' => ['html', 'js'],
                     'needs_environment' => true
                 ]
             ),
-        );
+        ];
     }
 
     /**


### PR DESCRIPTION
Method Twig_Function_Method was deprecated. Instead of it should use Twig_SimpleFunction. I fixed it in this PR and it works fine for me :)